### PR TITLE
fix the include pattern in tsconfig template

### DIFF
--- a/template/typescript/default/tsconfig.json
+++ b/template/typescript/default/tsconfig.json
@@ -25,7 +25,8 @@
     "skipLibCheck": true
   },
   "include": [
-    "./src/typed-router.d.ts"
+    "src/**/*",
+    "src/**/*.vue"
   ],
   "exclude": ["dist", "node_modules", "cypress"],
   "references": [{ "path": "./tsconfig.node.json" }],


### PR DESCRIPTION
Code intellisense in IDE doesn't work (such as the "@" path resolution) because of the wrong include pattern in the tsconfig.json file. 