### PR TITLE
feat: use fontsource for roboto font

### DIFF
--- a/template/javascript/base/vite.config.mjs
+++ b/template/javascript/base/vite.config.mjs
@@ -2,7 +2,7 @@
 import Components from 'unplugin-vue-components/vite'
 import Vue from '@vitejs/plugin-vue'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-import ViteFonts from 'unplugin-fonts/vite'
+import Fonts from 'unplugin-fonts/vite'
 import VueRouter from 'unplugin-vue-router/vite'
 
 // Utilities
@@ -24,12 +24,15 @@ export default defineConfig({
       },
     }),
     Components(),
-    ViteFonts({
-      google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+    Fonts({
+      fontsource: {
+        families: [
+          {
+            name: "Roboto",
+            weights: [100, 300, 400, 500, 700, 900],
+            styles: ["normal", "italic"],
+          },
+        ],
       },
     }),
   ],

--- a/template/javascript/default/package.json
+++ b/template/javascript/default/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "@mdi/font": "7.4.47",
-    "roboto-fontface": "*",
+    "@fontsource/roboto": "5.2.5",
     "vue": "^3.5.13",
     "vuetify": "^3.8.1"
   },

--- a/template/javascript/default/src/main.js
+++ b/template/javascript/default/src/main.js
@@ -13,6 +13,9 @@ import App from './App.vue'
 // Composables
 import { createApp } from 'vue'
 
+// Styles
+import 'unfonts.css'
+
 const app = createApp(App)
 
 registerPlugins(app)

--- a/template/javascript/default/vite.config.mjs
+++ b/template/javascript/default/vite.config.mjs
@@ -2,7 +2,7 @@
 import Components from 'unplugin-vue-components/vite'
 import Vue from '@vitejs/plugin-vue'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-import ViteFonts from 'unplugin-fonts/vite'
+import Fonts from 'unplugin-fonts/vite'
 
 // Utilities
 import { defineConfig } from 'vite'
@@ -17,12 +17,15 @@ export default defineConfig({
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme
     Vuetify(),
     Components(),
-    ViteFonts({
-      google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+    Fonts({
+      fontsource: {
+        families: [
+          {
+            name: 'Roboto',
+            weights: [100, 300, 400, 500, 700, 900],
+            styles: ['normal', 'italic'],
+          },
+        ],
       },
     }),
   ],

--- a/template/typescript/base/vite.config.mts
+++ b/template/typescript/base/vite.config.mts
@@ -2,7 +2,7 @@
 import Components from 'unplugin-vue-components/vite'
 import Vue from '@vitejs/plugin-vue'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-import ViteFonts from 'unplugin-fonts/vite'
+import Fonts from 'unplugin-fonts/vite'
 import VueRouter from 'unplugin-vue-router/vite'
 
 // Utilities
@@ -24,12 +24,15 @@ export default defineConfig({
       },
     }),
     Components(),
-    ViteFonts({
-      google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+    Fonts({
+      fontsource: {
+        families: [
+          {
+            name: "Roboto",
+            weights: [100, 300, 400, 500, 700, 900],
+            styles: ["normal", "italic"],
+          },
+        ],
       },
     }),
   ],

--- a/template/typescript/default/package.json
+++ b/template/typescript/default/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@mdi/font": "7.4.47",
-    "roboto-fontface": "*",
+    "@fontsource/roboto": "5.2.5",
     "vue": "^3.5.13",
     "vuetify": "^3.8.1"
   },

--- a/template/typescript/default/src/main.ts
+++ b/template/typescript/default/src/main.ts
@@ -13,6 +13,9 @@ import App from './App.vue'
 // Composables
 import { createApp } from 'vue'
 
+// Styles
+import 'unfonts.css'
+
 const app = createApp(App)
 
 registerPlugins(app)

--- a/template/typescript/default/vite.config.mts
+++ b/template/typescript/default/vite.config.mts
@@ -2,7 +2,7 @@
 import Components from 'unplugin-vue-components/vite'
 import Vue from '@vitejs/plugin-vue'
 import Vuetify, { transformAssetUrls } from 'vite-plugin-vuetify'
-import ViteFonts from 'unplugin-fonts/vite'
+import Fonts from 'unplugin-fonts/vite'
 
 // Utilities
 import { defineConfig } from 'vite'
@@ -17,12 +17,15 @@ export default defineConfig({
     // https://github.com/vuetifyjs/vuetify-loader/tree/master/packages/vite-plugin#readme
     Vuetify(),
     Components(),
-    ViteFonts({
-      google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+    Fonts({
+      fontsource: {
+        families: [
+          {
+            name: 'Roboto',
+            weights: [100, 300, 400, 500, 700, 900],
+            styles: ['normal', 'italic'],
+          },
+        ],
       },
     }),
   ],

--- a/template/typescript/essentials/vite.config.mts
+++ b/template/typescript/essentials/vite.config.mts
@@ -47,11 +47,14 @@ export default defineConfig({
       },
     }),
     Fonts({
-      google: {
-        families: [{
-          name: 'Roboto',
-          styles: 'wght@100;300;400;500;700;900',
-        }],
+      fontsource: {
+        families: [
+          {
+            name: 'Roboto',
+            weights: [100, 300, 400, 500, 700, 900],
+            styles: ['normal', 'italic'],
+          },
+        ],
       },
     }),
   ],


### PR DESCRIPTION
This PR is a part of bigger initiative to unify the way we are using the fonts across vuetifyjs repos
1. Switch from google fonts to fontsource (resolves https://github.com/vuetifyjs/create/issues/59)
2. Include italic variation (resolves https://github.com/vuetifyjs/create/issues/40)