### PR TITLE
fix: generate dts files inside `./src` in typescript-base template

### DIFF
--- a/template/typescript/base/vite.config.mts
+++ b/template/typescript/base/vite.config.mts
@@ -12,7 +12,9 @@ import { fileURLToPath, URL } from 'node:url'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    VueRouter(),
+    VueRouter({
+      dts: 'src/typed-router.d.ts',
+    }),
     Vue({
       template: { transformAssetUrls },
     }),
@@ -23,7 +25,9 @@ export default defineConfig({
         configFile: 'src/styles/settings.scss',
       },
     }),
-    Components(),
+    Components({
+      dts: 'src/components.d.ts',
+    }),
     Fonts({
       fontsource: {
         families: [


### PR DESCRIPTION
Currently we have a difference between base and essential preset. By default d.ts files were generated at root, which wasn't handled by tsconfig.json