### PR TITLE
feat: update vuetify to 3.9 and bump other dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "@types/node": "^22.13.10",
     "@types/prompts": "^2.4.9",
     "@types/validate-npm-package-name": "^4.0.2",
-    "esbuild": "^0.25.1",
-    "eslint": "^9.23.0",
+    "esbuild": "^0.25.6",
+    "eslint": "^9.30.1",
     "eslint-config-vuetify": "4.0.0",
     "nypm": "^0.6.0",
     "release-it": "^18.1.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   },
   "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228"
 }

--- a/src/utils/nuxt/versions.ts
+++ b/src/utils/nuxt/versions.ts
@@ -1,5 +1,5 @@
 export const versions = {
-  'vuetify': '^3.9.0',
+  'vuetify': '^3.9.1',
   'typescript': '^5.8.3',
   'vue-tsc': '^3.0.1',
   'sass-embedded': '^1.89.2',

--- a/src/utils/nuxt/versions.ts
+++ b/src/utils/nuxt/versions.ts
@@ -1,12 +1,12 @@
 export const versions = {
-  'vuetify': '^3.8.1',
-  'typescript': '^5.6.3',
-  'vue-tsc': '^2.1.6',
-  'sass-embedded': '^1.86.3',
+  'vuetify': '^3.9.0',
+  'typescript': '^5.8.3',
+  'vue-tsc': '^3.0.1',
+  'sass-embedded': '^1.89.2',
   '@vuetify/loader-shared': '^2.1.0',
   'vite-plugin-vuetify': '^2.1.1',
-  'vuetify-nuxt-module': '^0.18.6',
+  'vuetify-nuxt-module': '^0.18.7',
   'upath': '^2.0.1',
   '@mdi/font': '^7.4.47',
-  '@nuxt/fonts': '^0.11.1',
+  '@nuxt/fonts': '^0.11.4',
 } as const

--- a/template/javascript/base/package.json
+++ b/template/javascript/base/package.json
@@ -3,10 +3,9 @@
     "lint": "eslint . --fix"
   },
   "devDependencies": {
-    "eslint": "^9.23.0",
+    "eslint": "^9.30.1",
     "eslint-config-vuetify": "^4.0.0",
-    "globals": "^16.0.0",
-    "vue-router": "^4.5.0",
-    "unplugin-vue-router": "^0.12.0"
+    "vue-router": "^4.5.1",
+    "unplugin-vue-router": "^0.14.0"
   }
 }

--- a/template/javascript/default/package.json
+++ b/template/javascript/default/package.json
@@ -9,17 +9,16 @@
   },
   "dependencies": {
     "@mdi/font": "7.4.47",
-    "@fontsource/roboto": "5.2.5",
-    "vue": "^3.5.13",
-    "vuetify": "^3.8.1"
+    "@fontsource/roboto": "5.2.6",
+    "vue": "^3.5.17",
+    "vuetify": "^3.9.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",
-    "globals": "^16.0.0",
-    "sass-embedded": "^1.86.3",
+    "sass-embedded": "^1.89.2",
     "unplugin-fonts": "^1.3.1",
-    "unplugin-vue-components": "^28.4.1",
+    "unplugin-vue-components": "^28.8.0",
     "vite-plugin-vuetify": "^2.1.1",
-    "vite": "^6.2.2"
+    "vite": "^6.3.5"
   }
 }

--- a/template/javascript/default/package.json
+++ b/template/javascript/default/package.json
@@ -11,7 +11,7 @@
     "@mdi/font": "7.4.47",
     "@fontsource/roboto": "5.2.6",
     "vue": "^3.5.17",
-    "vuetify": "^3.9.0"
+    "vuetify": "^3.9.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/template/javascript/default/src/plugins/vuetify.js
+++ b/template/javascript/default/src/plugins/vuetify.js
@@ -14,6 +14,6 @@ import { createVuetify } from 'vuetify'
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
   theme: {
-    defaultTheme: 'dark',
+    defaultTheme: 'system',
   },
 })

--- a/template/javascript/essentials/package.json
+++ b/template/javascript/essentials/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "pinia" : "^3.0.1",
-    "unplugin-auto-import": "^19.1.1",
-    "vite-plugin-vue-layouts-next": "^0.0.8"
+    "pinia" : "^3.0.3",
+    "unplugin-auto-import": "^19.3.0",
+    "vite-plugin-vue-layouts-next": "^1.0.0"
   }
 }

--- a/template/javascript/essentials/package.json
+++ b/template/javascript/essentials/package.json
@@ -1,6 +1,8 @@
 {
+  "dependencies": {
+    "pinia" : "^3.0.3"
+  },
   "devDependencies": {
-    "pinia" : "^3.0.3",
     "unplugin-auto-import": "^19.3.0",
     "vite-plugin-vue-layouts-next": "^1.0.0"
   }

--- a/template/typescript/base/package.json
+++ b/template/typescript/base/package.json
@@ -3,9 +3,9 @@
     "lint": "eslint . --fix"
   },
   "devDependencies": {
-    "eslint": "^9.23.0",
+    "eslint": "^9.30.1",
     "eslint-config-vuetify": "^4.0.0",
-    "vue-router": "^4.5.0",
-    "unplugin-vue-router": "^0.12.0"
+    "vue-router": "^4.5.1",
+    "unplugin-vue-router": "^0.14.0"
   }
 }

--- a/template/typescript/default/package.json
+++ b/template/typescript/default/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@mdi/font": "7.4.47",
-    "@fontsource/roboto": "5.2.5",
-    "vue": "^3.5.13",
-    "vuetify": "^3.8.1"
+    "@fontsource/roboto": "5.2.6",
+    "vue": "^3.5.17",
+    "vuetify": "^3.9.0"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
@@ -21,12 +21,12 @@
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/tsconfig": "^0.7.0",
     "npm-run-all2": "^7.0.2",
-    "sass-embedded": "^1.86.3",
-    "typescript": "~5.8.2",
+    "sass-embedded": "^1.89.2",
+    "typescript": "~5.8.3",
     "unplugin-fonts": "^1.3.1",
-    "unplugin-vue-components": "^28.4.1",
+    "unplugin-vue-components": "^28.8.0",
     "vite-plugin-vuetify": "^2.1.1",
-    "vite": "^6.2.2",
-    "vue-tsc": "^2.2.8"
+    "vite": "^6.3.5",
+    "vue-tsc": "^3.0.1"
   }
 }

--- a/template/typescript/default/package.json
+++ b/template/typescript/default/package.json
@@ -13,7 +13,7 @@
     "@mdi/font": "7.4.47",
     "@fontsource/roboto": "5.2.6",
     "vue": "^3.5.17",
-    "vuetify": "^3.9.0"
+    "vuetify": "^3.9.1"
   },
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",

--- a/template/typescript/default/src/plugins/vuetify.ts
+++ b/template/typescript/default/src/plugins/vuetify.ts
@@ -14,6 +14,6 @@ import { createVuetify } from 'vuetify'
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
   theme: {
-    defaultTheme: 'dark',
+    defaultTheme: 'system',
   },
 })

--- a/template/typescript/essentials/package.json
+++ b/template/typescript/essentials/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
-    "pinia" : "^3.0.1",
-    "unplugin-auto-import": "^19.1.1",
-    "vite-plugin-vue-layouts-next": "^0.0.8"
+    "pinia" : "^3.0.3",
+    "unplugin-auto-import": "^19.3.0",
+    "vite-plugin-vue-layouts-next": "^1.0.0"
   }
 }

--- a/template/typescript/essentials/package.json
+++ b/template/typescript/essentials/package.json
@@ -1,6 +1,8 @@
 {
+  "dependencies": {
+    "pinia" : "^3.0.3"
+  },
   "devDependencies": {
-    "pinia" : "^3.0.3",
     "unplugin-auto-import": "^19.3.0",
     "vite-plugin-vue-layouts-next": "^1.0.0"
   }


### PR DESCRIPTION
- Update pinia, unplugin-auto-import, vite-plugin-vue-layouts-next in essentials templates
- Update eslint, vue-router, unplugin-vue-router in base templates
- Update vuetify, typescript, vue-tsc, sass-embedded in default templates
- Update esbuild, eslint, typescript in root package.json

> [!NOTE]
> This PR doesn't switch default theme in Nuxt, as it results in hydration mismatch (dark vs light theme)